### PR TITLE
 Remove redundant Continue field from AccessToken

### DIFF
--- a/section/dictionaries.html
+++ b/section/dictionaries.html
@@ -58,7 +58,6 @@
             required DOMString value;
             required DOMString manage;
             required unsigned short expires_in;
-            required Continue continue;
         };
     </pre>
     <h3>Continue</h3>


### PR DESCRIPTION
The Continue field in AccessToken was duplicating information already
available at the Grant response level, creating confusion about the
authoritative source of continuation data. Continue information should
only exist at the top-level Grant structure where algorithms expect it.